### PR TITLE
feat: Add RESP decoding functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.devcontainer
+.devcontainer/**
 .github
 bin/dice
 **.DS_Store

--- a/core/resp.go
+++ b/core/resp.go
@@ -1,0 +1,119 @@
+package core
+
+import "errors"
+
+// reads the length typically the first integer of the string
+// until hit by an non-digit byte and returns
+// the integer and the delta = length + 2 (CRLF)
+// TODO: Make it simpler and read until we get `\r` just like other functions
+func readLength(data []byte) (int, int) {
+	pos, length := 0, 0
+	for pos = range data {
+		b := data[pos]
+		if !(string(b) >= "0" && string(b) <= "9") {
+			return length, pos + 2
+		}
+		length = length*10 + int(b-'0')
+	}
+
+	return 0, 0
+}
+
+// reads a RESP encoded simple string from data and returns
+// the string, the delta, and the error
+func readSimpleString(data []byte) (string, int, error) {
+	// first character +
+	pos := 1
+
+	for ; data[pos] != '\r'; pos++ {
+	}
+
+	return string(data[1:pos]), pos + 2, nil
+}
+
+// reads a RESP encoded error from data and returns
+// the error string, the delta, and the error
+func readError(data []byte) (string, int, error) {
+	return readSimpleString(data)
+}
+
+// reads a RESP encoded integer from data and returns
+// the intger value, the delta, and the error
+func readInt64(data []byte) (int64, int, error) {
+	//first character :
+	pos := 1
+	var value int64 = 0
+
+	for ; data[pos] != '\r'; pos++ {
+		value = value*10 + int64(data[pos]-'0')
+	}
+
+	return value, pos + 2, nil
+}
+
+// reads a RESP encoded string from data and returns
+// the string, the delta, and the error
+func readBulkString(data []byte) (string, int, error) {
+	// first character $
+	pos := 1
+
+	// reading the length and forwarding the pos by
+	// the lenth of the integer + the first special character
+	len, delta := readLength(data[pos:])
+	pos += delta
+
+	// read len bytes as string
+	return string(data[pos : pos+len]), pos + len + 2, nil
+
+}
+
+// reads a RESP encoded array from data and returns
+// the array, the delta, and the error
+func readArray(data []byte) (interface{}, int, error) {
+	// first character *
+	pos := 1
+
+	// reading the length
+	count, delta := readLength(data[pos:])
+	pos += delta
+
+	var elems []interface{} = make([]interface{}, count)
+
+	for I := range elems {
+		elem, delta, err := DecodeOne(data[pos:])
+		if err != nil {
+			return nil, 0, err
+		}
+		elems[I] = elem
+		pos += delta
+
+	}
+	return elems, pos, nil
+}
+
+func DecodeOne(data []byte) (interface{}, int, error) {
+	if len(data) == 0 {
+		return nil, 0, errors.New("no data")
+	}
+	switch data[0] {
+	case '+':
+		return readSimpleString(data)
+	case '-':
+		return readError(data)
+	case ':':
+		return readInt64(data)
+	case '$':
+		return readBulkString(data)
+	case '*':
+		return readArray(data)
+	}
+	return nil, 0, nil
+}
+
+func Decode(data []byte) (interface{}, error) {
+	if len(data) == 0 {
+		return nil, errors.New("no data")
+	}
+	value, _, err := DecodeOne(data)
+	return value, err
+}

--- a/core/resp_test.go
+++ b/core/resp_test.go
@@ -1,0 +1,80 @@
+package core_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/subhande/goredis/core"
+)
+
+func TestSimpleStringDecode(t *testing.T) {
+	cases := map[string]string{
+		"+OK\r\n": "OK",
+	}
+	for k, v := range cases {
+		value, _ := core.Decode([]byte(k))
+		if v != value {
+			t.Fail()
+		}
+	}
+}
+
+func TestError(t *testing.T) {
+	cases := map[string]string{
+		"-Error message\r\n": "Error message",
+	}
+	for k, v := range cases {
+		value, _ := core.Decode([]byte(k))
+		if v != value {
+			t.Fail()
+		}
+	}
+}
+
+func TestInt64(t *testing.T) {
+	cases := map[string]int64{
+		":0\r\n":    0,
+		":1000\r\n": 1000,
+	}
+	for k, v := range cases {
+		value, _ := core.Decode([]byte(k))
+		if v != value {
+			t.Fail()
+		}
+	}
+}
+
+func TestBulkStringDecode(t *testing.T) {
+	cases := map[string]string{
+		"$5\r\nhello\r\n": "hello",
+		"$0\r\n\r\n":      "",
+	}
+	for k, v := range cases {
+		value, _ := core.Decode([]byte(k))
+		if v != value {
+			t.Fail()
+		}
+	}
+}
+
+func TestArrayDecode(t *testing.T) {
+	cases := map[string][]interface{}{
+		"*0\r\n":                                                   {},
+		"*2\r\n$5\r\nhello\r\n$5\r\nworld\r\n":                     {"hello", "world"},
+		"*3\r\n:1\r\n:2\r\n:3\r\n":                                 {int64(1), int64(2), int64(3)},
+		"*5\r\n:1\r\n:2\r\n:3\r\n:4\r\n$5\r\nhello\r\n":            {int64(1), int64(2), int64(3), int64(4), "hello"},
+		"*2\r\n*3\r\n:1\r\n:2\r\n:3\r\n*2\r\n+Hello\r\n-World\r\n": {[]int64{int64(1), int64(2), int64(3)}, []interface{}{"Hello", "World"}},
+	}
+	for k, v := range cases {
+		value, _ := core.Decode([]byte(k))
+		array := value.([]interface{})
+		if len(array) != len(v) {
+			t.Fail()
+		}
+		for i := range array {
+			if fmt.Sprintf("%v", v[i]) != fmt.Sprintf("%v", array[i]) {
+				t.Fail()
+			}
+		}
+	}
+}

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,1 @@
+go run main.go


### PR DESCRIPTION
This commit adds RESP decoding functions to the core package. These functions allow decoding of RESP encoded strings, errors, integers, bulk strings, and arrays. The functions are implemented in the `resp.go` file and are tested in the `resp_test.go` file.