### PR TITLE
feat: Add Redis command evaluation and response

### DIFF
--- a/core/cmd.go
+++ b/core/cmd.go
@@ -1,0 +1,6 @@
+package core
+
+type RedisCmd struct {
+	Cmd  string
+	Args []string
+}

--- a/core/eval.go
+++ b/core/eval.go
@@ -1,0 +1,34 @@
+package core
+
+import (
+	"errors"
+	"log"
+	"net"
+)
+
+func evalPING(args []string, c net.Conn) error {
+	var b []byte
+
+	if len(args) >= 2 {
+		return errors.New("ERR wrong number of arguments for 'ping' command")
+	}
+
+	if len(args) == 0 {
+		b = Encode("PONG", true)
+	} else {
+		b = Encode(args[0], false)
+	}
+
+	_, err := c.Write(b)
+	return err
+}
+
+func EvalAndRespond(cmd *RedisCmd, c net.Conn) error {
+	log.Println("comamnd:", cmd.Cmd)
+	switch cmd.Cmd {
+	case "PING":
+		return evalPING(cmd.Args, c)
+	default:
+		return evalPING(cmd.Args, c)
+	}
+}

--- a/core/resp.go
+++ b/core/resp.go
@@ -1,6 +1,9 @@
 package core
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 // reads the length typically the first integer of the string
 // until hit by an non-digit byte and returns
@@ -110,10 +113,35 @@ func DecodeOne(data []byte) (interface{}, int, error) {
 	return nil, 0, nil
 }
 
+func DecodeArrayString(data []byte) ([]string, error) {
+	value, err := Decode(data)
+	if err != nil {
+		return nil, err
+	}
+
+	ts := value.([]interface{})
+	tokens := make([]string, len(ts))
+	for i := range ts {
+		tokens[i] = ts[i].(string)
+	}
+	return tokens, nil
+}
+
 func Decode(data []byte) (interface{}, error) {
 	if len(data) == 0 {
 		return nil, errors.New("no data")
 	}
 	value, _, err := DecodeOne(data)
 	return value, err
+}
+
+func Encode(value interface{}, isSimple bool) []byte {
+	switch v := value.(type) {
+	case string:
+		if isSimple {
+			return []byte(fmt.Sprintf("+%s\r\n", v))
+		}
+		return []byte(fmt.Sprintf("$%d\r\n%s\r\n", len(v), v))
+	}
+	return []byte{}
 }

--- a/run_benchmark.sh
+++ b/run_benchmark.sh
@@ -1,0 +1,3 @@
+clear
+redis-benchmark -n 10000 -t ping_mbulk -c 1 -h localhost -p 6379
+redis-benchmark -n 10000 -t ping_mbulk -c 1 -h localhost -p 7379

--- a/server/sync_tcp.go
+++ b/server/sync_tcp.go
@@ -1,30 +1,47 @@
 package server
 
 import (
-	"github.com/subhande/goredis/config"
+	"fmt"
 	"io"
 	"log"
 	"net"
 	"strconv"
+	"strings"
+
+	"github.com/subhande/goredis/config"
+	"github.com/subhande/goredis/core"
 )
 
-func readCommand(c net.Conn) (string, error) {
+func readCommand(c net.Conn) (*core.RedisCmd, error) {
 	// TODO: Max read in one shot is 512 bytes
 	// tesTo allow input > 512 by, then repeated read until
 	// we get EOF or designated delimiter
 	var buf []byte = make([]byte, 512)
 	n, err := c.Read(buf)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return string(buf[:n]), nil
+
+	tokens, err := core.DecodeArrayString(buf[:n])
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	return &core.RedisCmd{Cmd: strings.ToUpper(tokens[0]), Args: tokens[1:]}, nil
+
 }
 
-func respond(cmd string, c net.Conn) error {
-	if _, err := c.Write([]byte(cmd)); err != nil {
-		return err
+func respondError(err error, c net.Conn) {
+	c.Write([]byte(fmt.Sprintf("-%s\r\n", err)))
+}
+
+func respond(cmd *core.RedisCmd, c net.Conn) {
+	err := core.EvalAndRespond(cmd, c)
+	if err != nil {
+		respondError(err, c)
 	}
-	return nil
 }
 
 func RunSyncTCPServer() {
@@ -65,10 +82,7 @@ func RunSyncTCPServer() {
 				}
 				log.Println("err", err)
 			}
-			log.Println("command", cmd)
-			if err = respond(cmd, c); err != nil {
-				log.Print("err write:", err)
-			}
+			respond(cmd, c)
 
 		}
 	}


### PR DESCRIPTION
This commit adds the evaluation and response logic for Redis commands in the synchronous TCP server. It introduces the `EvalAndRespond` function in the `eval.go` file, which evaluates the received command and sends the appropriate response back to the client. This functionality is implemented for the `PING` command, and a default response is provided for unknown commands.