### PR TITLE
feat: Add SET, GET, and TTL command evaluation and response

### DIFF
--- a/core/eval.go
+++ b/core/eval.go
@@ -4,7 +4,11 @@ import (
 	"errors"
 	"io"
 	"log"
+	"strconv"
+	"time"
 )
+
+var RESP_NIL []byte = []byte("$-1\r\n")
 
 func evalPING(args []string, c io.ReadWriter) error {
 	var b []byte
@@ -23,11 +27,113 @@ func evalPING(args []string, c io.ReadWriter) error {
 	return err
 }
 
+func evalSET(args []string, c io.ReadWriter) error {
+	if len(args) <= 1 {
+		return errors.New("(error) ERR wrong number of arguments for 'set' command")
+	}
+	var key, value string
+	var exDurationMs int64 = -1
+
+	key, value = args[0], args[1]
+
+	for i := 2; i < len(args); i++ {
+		switch args[i] {
+		case "EX", "ex":
+			i++
+			if i == len(args) {
+				return errors.New("(error) ERR syntax error")
+			}
+
+			exDurationSec, err := strconv.ParseInt(args[3], 10, 64)
+			if err != nil {
+				return errors.New("(error) ERR value is not an integer or out of range")
+			}
+			exDurationMs = exDurationSec * 1000
+		default:
+			return errors.New("(error) ERR syntax error")
+
+		}
+	}
+
+	// putting the k and value in a Hash Table
+	Put(key, NewObj(value, exDurationMs))
+	c.Write([]byte("+OK\r\n"))
+	return nil
+}
+
+func evalGET(args []string, c io.ReadWriter) error {
+	if len(args) != 1 {
+		return errors.New("(error) ERR wrong number of arguments for 'get' command")
+	}
+
+	var key string = args[0]
+
+	// Get the key from the hash table
+	obj := Get(key)
+
+	// if key does not exist, return RESP encoded nil
+	if obj == nil {
+		c.Write(RESP_NIL)
+		return nil
+	}
+
+	// if key already expired then return nil
+	if obj.ExpiresAt != -1 && obj.ExpiresAt <= time.Now().UnixMilli() {
+		c.Write(RESP_NIL)
+		return nil
+	}
+
+	// return the RESP encoded value
+	c.Write(Encode(obj.Value, false))
+	return nil
+}
+
+func evalTTL(args []string, c io.ReadWriter) error {
+	if len(args) != 1 {
+		return errors.New("(error) ERR wrong number of arguments for 'ttl' command")
+	}
+
+	var key string = args[0]
+
+	obj := Get(key)
+
+	// if key does not exist, return RESP encoded -2 denoting key does not exist
+	if obj == nil {
+		c.Write([]byte(":-2\r\n"))
+		return nil
+	}
+
+	// if object exist, but no expiration is set on it then send -1
+	if obj.ExpiresAt == -1 {
+		c.Write([]byte(":-1\r\n"))
+		return nil
+	}
+
+	// compute the time remaining for the key to expire and
+	// return the RESP encoded form of it
+	durationMs := obj.ExpiresAt - time.Now().UnixMilli()
+
+	// if key expired i.e. key does not exist hence return -2
+	if durationMs < 0 {
+		c.Write([]byte(":-2\r\n"))
+		return nil
+	}
+
+	c.Write(Encode(int64(durationMs/1000), false))
+	return nil
+}
+
 func EvalAndRespond(cmd *RedisCmd, c io.ReadWriter) error {
 	log.Println("comamnd:", cmd.Cmd)
 	switch cmd.Cmd {
 	case "PING":
 		return evalPING(cmd.Args, c)
+	case "SET":
+		return evalSET(cmd.Args, c)
+	case "GET":
+		return evalGET(cmd.Args, c)
+	case "TTL":
+		return evalTTL(cmd.Args, c)
 	default:
 		return evalPING(cmd.Args, c)
 	}

--- a/core/resp.go
+++ b/core/resp.go
@@ -142,6 +142,9 @@ func Encode(value interface{}, isSimple bool) []byte {
 			return []byte(fmt.Sprintf("+%s\r\n", v))
 		}
 		return []byte(fmt.Sprintf("$%d\r\n%s\r\n", len(v), v))
+	case int64:
+		return []byte(fmt.Sprintf(":%d\r\n", v))
+	default:
+		return RESP_NIL
 	}
-	return []byte{}
 }

--- a/core/store.go
+++ b/core/store.go
@@ -1,0 +1,34 @@
+package core
+
+import "time"
+
+var store map[string]*Obj
+
+type Obj struct {
+	Value     interface{}
+	ExpiresAt int64
+}
+
+func init() {
+	store = make(map[string]*Obj)
+}
+
+func NewObj(value interface{}, durationMs int64) *Obj {
+	var expiresAt int64 = -1
+	if durationMs > 0 {
+		expiresAt = time.Now().UnixMilli() + durationMs
+	}
+
+	return &Obj{
+		Value:     value,
+		ExpiresAt: expiresAt,
+	}
+}
+
+func Put(k string, obj *Obj) {
+	store[k] = obj
+}
+
+func Get(k string) *Obj {
+	return store[k]
+}

--- a/run_benchmark.sh
+++ b/run_benchmark.sh
@@ -1,3 +1,5 @@
 clear
-redis-benchmark -n 10000 -t ping_mbulk -c 1 -h localhost -p 6379
-redis-benchmark -n 10000 -t ping_mbulk -c 1 -h localhost -p 7379
+# redis-benchmark -n 10000 -t ping_mbulk -c 1 -h localhost -p 6379
+# redis-benchmark -n 10000 -t ping_mbulk -c 1 -h localhost -p 7379
+redis-benchmark -n 10000 -t ping_mbulk -c 200 -h localhost -p 6379
+redis-benchmark -n 10000 -t ping_mbulk -c 200 -h localhost -p 7379


### PR DESCRIPTION
This commit adds the evaluation and response logic for the SET, GET, and TTL commands in the synchronous TCP server. It introduces the `evalSET`, `evalGET`, and `evalTTL` functions in the `eval.go` file, which handle the respective commands and send the appropriate responses back to the client. These functionalities allow users to set a key-value pair, retrieve the value of a key, and check the time-to-live (TTL) of a key.