### PR TITLE
```text

### DIFF
--- a/config/main.go
+++ b/config/main.go
@@ -2,3 +2,5 @@ package config
 
 var Host string = "0.0.0.0"
 var Port int = 7379
+var KeysLimit int = 5
+var EvictionStrategy string = "simple-first"

--- a/core/eviction.go
+++ b/core/eviction.go
@@ -1,0 +1,27 @@
+package core
+
+import (
+	"log"
+
+	"github.com/subhande/goredis/config"
+)
+
+// Evicts the first key it found while iterating the map
+// TODO: Make it efficient by doing thorough sampling
+
+func evictFirst() {
+	for k := range store {
+		delete(store, k)
+		log.Println("evicting key: ", k)
+		return
+	}
+}
+
+// TODO: Make the eviction strategy configuration driven
+// TODO: Support multiple eviction strategies
+func evict() {
+	switch config.EvictionStrategy {
+	case "simple-first":
+		evictFirst()
+	}
+}

--- a/core/store.go
+++ b/core/store.go
@@ -3,6 +3,8 @@ package core
 import (
 	"log"
 	"time"
+
+	"github.com/subhande/goredis/config"
 )
 
 var store map[string]*Obj
@@ -29,6 +31,9 @@ func NewObj(value interface{}, durationMs int64) *Obj {
 }
 
 func Put(k string, obj *Obj) {
+	if len(store) >= config.KeysLimit {
+		evict()
+	}
 	store[k] = obj
 }
 


### PR DESCRIPTION
feat: Add eviction strategy configuration and implementation

This commit introduces the configuration and implementation of an eviction strategy for the Redis server. It adds a new configuration variable `EvictionStrategy` in the `config/main.go` file, which allows users to specify the eviction strategy for the server. Additionally, a new file `core/eviction.go` is added, which contains the logic for evicting keys based on the chosen strategy. The current implementation supports a simple-first eviction strategy, where the first key encountered during iteration is evicted. This functionality is triggered when the number of keys in the store exceeds the configured limit specified by `KeysLimit`.