### PR TITLE
feat: Add support for AOF file and dump all keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .github
 bin/dice
 **.DS_Store
+*.aof

--- a/config/main.go
+++ b/config/main.go
@@ -4,3 +4,4 @@ var Host string = "0.0.0.0"
 var Port int = 7379
 var KeysLimit int = 5
 var EvictionStrategy string = "simple-first"
+var AOFFile string = "./goredis-master.aof"

--- a/core/aof.go
+++ b/core/aof.go
@@ -1,0 +1,36 @@
+package core
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/subhande/goredis/config"
+)
+
+// TODO: Support Expiration
+// TODO: Support non-kv data structures
+// TODO: Support sync write
+func dumpKey(fp *os.File, key string, obj *Obj) {
+	cmd := fmt.Sprintf("SET %s %s", key, obj.Value)
+	log.Println("dumping", cmd)
+	tokens := strings.Split(cmd, " ")
+	log.Println("tokens", tokens)
+	log.Println("encoded tokens", Encode(tokens, false))
+	fp.Write(Encode(tokens, false))
+}
+
+// TODO: To to new and switch
+func DumpAllAOF() {
+	fp, err := os.OpenFile(config.AOFFile, os.O_CREATE|os.O_WRONLY, os.ModeAppend)
+	if err != nil {
+		fmt.Print("error", err)
+		return
+	}
+	log.Println("rewriting AOF file at", config.AOFFile)
+	for k, obj := range store {
+		dumpKey(fp, k, obj)
+	}
+	log.Println("AOF file rewrite complete")
+}

--- a/core/eval.go
+++ b/core/eval.go
@@ -155,6 +155,12 @@ func evalEXPIRE(args []string) []byte {
 	return RESP_ONE
 }
 
+// TODO: Make it async by forking a new process
+func evalBGREWRITEAOF(args []string) []byte {
+	DumpAllAOF()
+	return RESP_OK
+}
+
 func EvalAndRespond(cmds RedisCmds, c io.ReadWriter) {
 	var response []byte
 	buf := bytes.NewBuffer(response)
@@ -173,6 +179,8 @@ func EvalAndRespond(cmds RedisCmds, c io.ReadWriter) {
 			buf.Write(evalDEL(cmd.Args))
 		case "EXPIRE":
 			buf.Write(evalEXPIRE(cmd.Args))
+		case "BGREWRITEAOF":
+			buf.Write(evalBGREWRITEAOF(cmd.Args))
 		default:
 			buf.Write(evalPING(cmd.Args))
 		}

--- a/core/resp.go
+++ b/core/resp.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 )
@@ -145,15 +146,26 @@ func Decode(data []byte) ([]interface{}, error) {
 	return values, nil
 }
 
+func encodeString(v string) []byte {
+	return []byte(fmt.Sprintf("$%d\r\n%s\r\n", len(v), v))
+}
+
 func Encode(value interface{}, isSimple bool) []byte {
 	switch v := value.(type) {
 	case string:
 		if isSimple {
 			return []byte(fmt.Sprintf("+%s\r\n", v))
 		}
-		return []byte(fmt.Sprintf("$%d\r\n%s\r\n", len(v), v))
+		return encodeString(v)
 	case int, int8, int16, int32, int64:
 		return []byte(fmt.Sprintf(":%d\r\n", v))
+	case []string:
+		var b []byte
+		buf := bytes.NewBuffer(b)
+		for _, b := range value.([]string) {
+			buf.Write(encodeString(b))
+		}
+		return []byte(fmt.Sprintf("*%d\r\n%s", len(v), buf.Bytes()))
 	case error:
 		return []byte(fmt.Sprintf("-%s\r\n", v))
 	default:


### PR DESCRIPTION
This commit adds support for an AOF (Append-Only File) in the Redis server. It introduces a new configuration variable `AOFFile` in the `config/main.go` file, which specifies the file path for the AOF. Additionally, a new file `core/aof.go` is added, which contains functions for dumping all keys to the AOF file and rewriting the AOF file. The `DumpAllAOF` function is responsible for iterating over all keys in the store and writing the corresponding SET commands to the AOF file. The `evalBGREWRITEAOF` function is added to evaluate the BGREWRITEAOF command, which triggers the rewriting of the AOF file.