### PR TITLE
feat: Update eviction strategy to use LRU algorithm

### DIFF
--- a/config/main.go
+++ b/config/main.go
@@ -6,7 +6,7 @@ var KeysLimit int = 100
 
 // Will evict EvictionRatio of keys whenever eviction runs
 var EvictionRatio float64 = 0.4
-var EvictionStrategy string = "allkeys-random"
+var EvictionStrategy string = "allkeys-lru"
 // var EvictionStrategy string = "simple-first"
 
 var AOFFile string = "./goredis-master.aof"

--- a/core/eval.go
+++ b/core/eval.go
@@ -82,7 +82,7 @@ func evalGET(args []string) []byte {
 	}
 
 	// if key already expired then return nil
-	if obj.ExpiresAt != -1 && obj.ExpiresAt <= time.Now().UnixMilli() {
+	if hasExpired(obj) {
 		return RESP_NIL
 	}
 
@@ -105,18 +105,19 @@ func evalTTL(args []string) []byte {
 	}
 
 	// if object exist, but no expiration is set on it then send -1
-	if obj.ExpiresAt == -1 {
+	exp, isExpirySet := getExpiry(obj)
+	if !isExpirySet {
 		return RESP_MINUS_1
+	}
+
+	// if key expired i.e. key does not exist hence return -2
+	if exp < uint64(time.Now().UnixMilli()) {
+		return RESP_MINUS_2
 	}
 
 	// compute the time remaining for the key to expire and
 	// return the RESP encoded form of it
-	durationMs := obj.ExpiresAt - time.Now().UnixMilli()
-
-	// if key expired i.e. key does not exist hence return -2
-	if durationMs < 0 {
-		return RESP_MINUS_2
-	}
+	durationMs := exp - uint64(time.Now().UnixMilli())
 
 	return Encode(int64(durationMs/1000), false)
 }
@@ -151,7 +152,7 @@ func evalEXPIRE(args []string) []byte {
 		return RESP_ZERO
 	}
 
-	obj.ExpiresAt = time.Now().UnixMilli() + exDurationSec*1000
+	setExpiry(obj, exDurationSec*1000)
 
 	// 1 if the timeout was set.
 	return RESP_ONE
@@ -209,6 +210,11 @@ func evalLATENCY(args []string) []byte {
 	return Encode([]string{}, false)
 }
 
+func evalLRU(args []string) []byte {
+	evictAllkeysLRU()
+	return RESP_OK
+}
+
 func EvalAndRespond(cmds RedisCmds, c io.ReadWriter) {
 	var response []byte
 	buf := bytes.NewBuffer(response)
@@ -237,6 +243,8 @@ func EvalAndRespond(cmds RedisCmds, c io.ReadWriter) {
 			buf.Write(evalCLIENT(cmd.Args))
 		case "LATENCY":
 			buf.Write(evalLATENCY(cmd.Args))
+		case "LRU":
+			buf.Write(evalLRU(cmd.Args))
 		default:
 			buf.Write(evalPING(cmd.Args))
 		}

--- a/core/eviction.go
+++ b/core/eviction.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"log"
+	"time"
 
 	"github.com/subhande/goredis/config"
 )
@@ -35,13 +36,55 @@ func evictAllkeysRandom() {
 
 }
 
-// TODO: Make the eviction strategy configuration driven
-// TODO: Support multiple eviction strategies
+/*
+ *  The approximated LRU algorithm
+ */
+func getCurrentClock() uint32 {
+	return uint32(time.Now().Unix()) & 0x00FFFFFF
+}
+
+func getIdleTime(lastAccessedAt uint32) uint32 {
+	c := getCurrentClock()
+	if c >= lastAccessedAt {
+		return c - lastAccessedAt
+	}
+	return (0x00FFFFFF - lastAccessedAt) + c
+}
+
+func populateEvictionPool() {
+	sampleSize := 5
+	for k := range store {
+		ePool.Push(k, store[k].LastAccessedAt)
+		sampleSize--
+		if sampleSize == 0 {
+			break
+		}
+	}
+}
+
+// TODO: no need to populate everytime. should populate
+// only when the number of keys to evict is less than what we have in the pool
+func evictAllkeysLRU() {
+	populateEvictionPool()
+	evictCount := int16(config.EvictionRatio * float64(config.KeysLimit))
+	for i := 0; i < int(evictCount) && len(ePool.pool) > 0; i++ {
+		item := ePool.Pop()
+		if item == nil {
+			return
+		}
+		Del(item.key)
+		log.Println("evicting key: ", item.key)
+	}
+}
+
+// TODO: implement LFU
 func evict() {
 	switch config.EvictionStrategy {
 	case "simple-first":
 		evictFirst()
 	case "allkeys-random":
 		evictAllkeysRandom()
+	case "allkeys-lru":
+		evictAllkeysLRU()
 	}
 }

--- a/core/evictionpool.go
+++ b/core/evictionpool.go
@@ -1,0 +1,71 @@
+package core
+
+import (
+	"sort"
+)
+
+type PoolItem struct {
+	key            string
+	lastAccessedAt uint32
+}
+
+// TODO: When last accessed at of object changes
+// update the poolItem correponding to that
+type EvictionPool struct {
+	pool   []*PoolItem
+	keyset map[string]*PoolItem
+}
+
+type ByIdleTime []*PoolItem
+
+func (a ByIdleTime) Len() int {
+	return len(a)
+}
+
+func (a ByIdleTime) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+
+func (a ByIdleTime) Less(i, j int) bool {
+	return getIdleTime(a[i].lastAccessedAt) > getIdleTime(a[j].lastAccessedAt)
+}
+
+// TODO: Make the implementation efficient to not need repeated sorting
+func (pq *EvictionPool) Push(key string, lastAccessedAt uint32) {
+	_, ok := pq.keyset[key]
+	if ok {
+		return
+	}
+	item := &PoolItem{key: key, lastAccessedAt: lastAccessedAt}
+	if len(pq.pool) < ePoolSizeMax {
+		pq.keyset[key] = item
+		pq.pool = append(pq.pool, item)
+
+		// Performance bottleneck
+		sort.Sort(ByIdleTime(pq.pool))
+	} else if lastAccessedAt > pq.pool[0].lastAccessedAt {
+		pq.pool = pq.pool[1:]
+		pq.keyset[key] = item
+		pq.pool = append(pq.pool, item)
+	}
+}
+
+func (pq *EvictionPool) Pop() *PoolItem {
+	if len(pq.pool) == 0 {
+		return nil
+	}
+	item := pq.pool[0]
+	pq.pool = pq.pool[1:]
+	delete(pq.keyset, item.key)
+	return item
+}
+
+func newEvictionPool(size int) *EvictionPool {
+	return &EvictionPool{
+		pool:   make([]*PoolItem, size),
+		keyset: make(map[string]*PoolItem),
+	}
+}
+
+var ePoolSizeMax int = 16
+var ePool *EvictionPool = newEvictionPool(0)

--- a/core/expire.go
+++ b/core/expire.go
@@ -1,9 +1,21 @@
 package core
 
 import (
-	"log"
 	"time"
 )
+
+func hasExpired(obj *Obj) bool {
+	exp, ok := expires[obj]
+	if !ok {
+		return false
+	}
+	return exp <= uint64(time.Now().UnixMilli())
+}
+
+func getExpiry(obj *Obj) (uint64, bool) {
+	exp, ok := expires[obj]
+	return exp, ok
+}
 
 //TODO: Optimize
 // - Sampling
@@ -15,14 +27,10 @@ func expireSample() float32 {
 
 	// assuming iteration of golang hash table in randomized
 	for key, obj := range store {
-		if obj.ExpiresAt != -1 {
-			limit--
-			// if key is expired
-			if obj.ExpiresAt <= time.Now().UnixMilli() {
-				Del(key)
-				log.Println("deleted key", key, "as it was expired")
-				expiredCount++
-			}
+		limit--
+		if hasExpired(obj) {
+			Del(key)
+			expiredCount++
 		}
 
 		// once we iterated to 20 keys that have some expiration set

--- a/core/object.go
+++ b/core/object.go
@@ -3,8 +3,13 @@ package core
 // TODO: change ExpiresAt it to LRU Bits as handled by Redis
 type Obj struct {
 	TypeEncoding uint8
-	Value        interface{}
-	ExpiresAt    int64
+	// Redis allots 24 bits to these bits, but we will use 32 bits because
+	// golang does not support bitfields and we need not make this super-complicated
+	// by merging TypeEncoding + LastAccessedAt in one 32 bit integer.
+	// But nonetheless, we can benchmark and see how that fares.
+	// For now, we continue with 32 bit integer to store the LastAccessedAt
+	LastAccessedAt uint32
+	Value          interface{}
 }
 
 var OBJ_TYPE_STRING uint8 = 0 << 4

--- a/core/store.go
+++ b/core/store.go
@@ -8,28 +8,35 @@ import (
 )
 
 var store map[string]*Obj
+var expires map[*Obj]uint64
 
 func init() {
 	store = make(map[string]*Obj)
+	expires = make(map[*Obj]uint64)
 }
 
-func NewObj(value interface{}, durationMs int64, oType uint8, oEnc uint8) *Obj {
-	var expiresAt int64 = -1
-	if durationMs > 0 {
-		expiresAt = time.Now().UnixMilli() + durationMs
+func setExpiry(obj *Obj, expDurationMs int64) {
+	expires[obj] = uint64(time.Now().UnixMilli()) + uint64(expDurationMs)
+}
+
+func NewObj(value interface{}, expDurationMs int64, oType uint8, oEnc uint8) *Obj {
+	obj := &Obj{
+		Value:          value,
+		TypeEncoding:   oType | oEnc,
+		LastAccessedAt: getCurrentClock(),
 	}
 
-	return &Obj{
-		Value:        value,
-		TypeEncoding: oType | oEnc,
-		ExpiresAt:    expiresAt,
+	if expDurationMs > 0 {
+		setExpiry(obj, expDurationMs)
 	}
+	return obj
 }
 
 func Put(k string, obj *Obj) {
 	if len(store) >= config.KeysLimit {
 		evict()
 	}
+	obj.LastAccessedAt = getCurrentClock()
 	store[k] = obj
 	if KeyspaceStat[0] == nil {
 		KeyspaceStat[0] = make(map[string]int)
@@ -40,7 +47,7 @@ func Put(k string, obj *Obj) {
 func Get(k string) *Obj {
 	v := store[k]
 	if v != nil {
-		if v.ExpiresAt != -1 && v.ExpiresAt <= time.Now().UnixMilli() {
+		if hasExpired(v) {
 			Del(k)
 			log.Println("passive delete | key: ", k, "as it was expired")
 			return nil
@@ -50,8 +57,9 @@ func Get(k string) *Obj {
 }
 
 func Del(k string) bool {
-	if _, ok := store[k]; ok {
+	if obj, ok := store[k]; ok {
 		delete(store, k)
+		delete(expires, obj)
 		KeyspaceStat[0]["keys"]--
 		return true
 	}


### PR DESCRIPTION
This commit updates the eviction strategy in the Redis server to use the LRU (Least Recently Used) algorithm. It modifies the `core/eviction.go` file to implement the `evictAllkeysLRU` function, which populates an eviction pool based on the last accessed time of keys and evicts the least recently used keys when the number of keys to evict exceeds the configured limit. The `getCurrentClock` function is added to get the current time in Unix format, and the `getIdleTime` function calculates the idle time of keys based on the current time and their last accessed time. This change improves the efficiency of key eviction in the Redis server.